### PR TITLE
Add the option to change players thinking delay

### DIFF
--- a/src/computer-players/computer-factory.ts
+++ b/src/computer-players/computer-factory.ts
@@ -4,17 +4,27 @@ import { createRandomPlayerMachine } from "./random-player-machine";
 import { getRandomTake } from "./randomness";
 import { createSmartPlayerMachine } from "./smart-player-machine";
 
+declare global {
+  var thinkingDelay: number | undefined;
+}
+
 export const computerFactory: PlayerFactory = (config) => {
   switch (config.difficulty) {
     case "medium":
       return spawn(
         createRandomPlayerMachine({
           secret: config.secret,
+          thinkingDelay: globalThis.thinkingDelay ?? 2000,
           getRandomTake,
         })
       );
     case "extreme":
-      return spawn(createSmartPlayerMachine(config));
+      return spawn(
+        createSmartPlayerMachine({
+          secret: config.secret,
+          thinkingDelay: globalThis.thinkingDelay ?? 2000,
+        })
+      );
     default:
       throw new Error("Unknown game difficulty: " + config.difficulty);
   }

--- a/src/computer-players/random-player-machine.test.ts
+++ b/src/computer-players/random-player-machine.test.ts
@@ -19,6 +19,7 @@ describe("Random Player Actor", () => {
   beforeEach(() => {
     deps = mockDeep<RandomPlayerDependencies>({
       secret: "comm-secret",
+      thinkingDelay: 2000,
     });
     deps.getRandomTake.mockReturnValue(1);
   });
@@ -42,6 +43,24 @@ describe("Random Player Actor", () => {
     actor.send(requestMove(pile));
 
     clock.increment(1999);
+    expect(parent.send).not.toBeCalled();
+
+    clock.increment(1);
+    expect(parent.send).toBeCalledTimes(1);
+  });
+
+  it("should change it thinking speed based on the provided delay", () => {
+    deps.thinkingDelay = 1; // <-- Changed delay
+    const parent = mockDeep<AnyInterpreter>();
+    const clock = new SimulatedClock();
+    const actor = interpret(createRandomPlayerMachine(deps), {
+      clock,
+      parent,
+    }).start();
+
+    const pile = createPile();
+    actor.send(requestMove(pile));
+
     expect(parent.send).not.toBeCalled();
 
     clock.increment(1);

--- a/src/computer-players/random-player-machine.ts
+++ b/src/computer-players/random-player-machine.ts
@@ -18,11 +18,12 @@ function getInitialContext(): RandomPlayerContext {
 export interface RandomPlayerDependencies {
   /** The `secret` is provided by the game manager to verify moves from this actor. */
   secret: string;
+  thinkingDelay: number;
   getRandomTake(): AllowedMoveLength;
 }
 
 export function createRandomPlayerMachine(deps: RandomPlayerDependencies) {
-  /** @xstate-layout N4IgpgJg5mDOIC5QCUCGA7CB7AtgBQBtUBPMAJwDoBJCAsAYilRzApywDc4KywBHAK5wALolAAHLLACWw6VnRiQAD0QBGACwaKABgCcegOwAOAGzHjmvRp3GANCGKIATPooGDAZlvHPh5-6GAL5BDmiYuIQk5BQAKgAW0ugA1klQ9MqwwqjCrKgAZrlkABSuOjoAlPTh2PhEpJQJSanoUEqSMnIKSqoIGta6ns5DGgCseqMapnoOTgjOznoU-V6uhoaj5nqeIWEYtVENFADKAlAwWWkAspwMTCxst7AUqADGr2DiokggHbLyih+vSGamWejUi22pkMelczlm6mcpgoEP0Qz00z8WlGuxANUi9Rip3OImut0YzFY7C4zwgYFeBCSYHaUn+3SBiEMak8FFMNg8Fk0ZjUCIQEORqO2i0xhmxIVCIHQWDp8B++Lq0UoNDoLM6AJ6iFGowocO2nj0xlGnm8OkMooWPJWE2G-mM61MOwV6sOMSaKTSurZgNAwPGJv8Rs8kw9plMOlG9uGYIMoxdzjdhlMuO9hMoxIuclaNy4ga6wZUiA9Sw0fitanjo1sOnhjnUMPcHg06YWmg0amz+wJmtL+o5CE8oNN1otVptdtbCEmKNc1lM9bUHu8-flQA */
+  /** @xstate-layout N4IgpgJg5mDOIC5QCUCGA7CB7AtgBQBtUBPMAJwDoBJCAsAYilRzApywDc4KywBHAK5wALolAAHLLACWw6VnRiQAD0QBGACwaKABgCcegOwAOAGzHjmvRp3GANCGKIATPooGDAZlvHPh5-6GAL5BDmiYuIQk5BQAKgAW0ugA1klQ9MqwwqjCrKgAZrlkABTCiSlpAJT04dj4RKSUCUmp6FBKkjJyCkqqCBqGAKwUanqDzsaGhp6eg6ZzDk4Izs56FBoexl6r04amIWEYdVGNFADKAlAwWWkAspwMTCxsD7AUqADGH2DiokggnVk8kU-z6nmcanWejUqz0nlMhj0rmci3UzlMI1ccNWpjhhi0gwOIFqkQaMQuVxEdwejGYrHYXDeEDAHwISTAHSkQJ6oMQhjUngophsm0sGjMalRCBhGJh+nBelxfgJIVCIHQWGZ8H+JPq0UoNDonK6wN6iEGw2RcM8emMgxmOh0hilK0FGwM4z8Eympk8RN1JxizQqbWN3JBoDBgzWAWcFtmGl9plMOkGLucbo8nv8kz2-qOpP150u1zkbXuXDD3QjKkQvrWGj89rUqcGth0KMc6kR7g8GgmK00GjU+YiesaVdNvIQnkhVpmtvt3idUsG2jl0OHW3BvuCqqAA */
   return createMachine(
     {
       context: getInitialContext(),
@@ -42,7 +43,7 @@ export function createRandomPlayerMachine(deps: RandomPlayerDependencies) {
         },
         Thinking: {
           after: {
-            "2000": {
+            thinking: {
               target: "SuggestingMove",
             },
           },
@@ -62,6 +63,9 @@ export function createRandomPlayerMachine(deps: RandomPlayerDependencies) {
       },
     },
     {
+      delays: {
+        thinking: () => deps.thinkingDelay,
+      },
       actions: {
         saveGameState: assign((_, e) => ({
           freePos: getFreePositions(e.pile),

--- a/src/computer-players/random-player-machine.typegen.ts
+++ b/src/computer-players/random-player-machine.typegen.ts
@@ -3,8 +3,8 @@
 export interface Typegen0 {
   "@@xstate/typegen": true;
   internalEvents: {
-    "xstate.after(2000)#RandomPlayer.Thinking": {
-      type: "xstate.after(2000)#RandomPlayer.Thinking";
+    "xstate.after(thinking)#RandomPlayer.Thinking": {
+      type: "xstate.after(thinking)#RandomPlayer.Thinking";
     };
     "xstate.init": { type: "xstate.init" };
   };
@@ -18,15 +18,17 @@ export interface Typegen0 {
   eventsCausingActions: {
     calculateMove:
       | "game.moves.decline"
-      | "xstate.after(2000)#RandomPlayer.Thinking";
+      | "xstate.after(thinking)#RandomPlayer.Thinking";
     respondWithMove:
       | "game.moves.decline"
-      | "xstate.after(2000)#RandomPlayer.Thinking";
+      | "xstate.after(thinking)#RandomPlayer.Thinking";
     saveGameState: "game.moves.request";
   };
   eventsCausingServices: {};
   eventsCausingGuards: {};
-  eventsCausingDelays: {};
+  eventsCausingDelays: {
+    thinking: "game.moves.request";
+  };
   matchesStates: "Idle" | "SuggestingMove" | "Thinking";
   tags: never;
 }

--- a/src/computer-players/smart-player-machine.test.ts
+++ b/src/computer-players/smart-player-machine.test.ts
@@ -24,12 +24,13 @@ function buildPile() {
   return pile;
 }
 
-describe("Random Player Actor", () => {
+describe("Smart Player Actor", () => {
   let deps: DeepMockProxy<SmartPlayerDependencies>;
 
   beforeEach(() => {
     deps = mockDeep<SmartPlayerDependencies>({
       secret: "comm-secret",
+      thinkingDelay: 2000,
     });
   });
 
@@ -52,6 +53,24 @@ describe("Random Player Actor", () => {
     actor.send(requestMove(pile));
 
     clock.increment(1999);
+    expect(parent.send).not.toBeCalled();
+
+    clock.increment(1);
+    expect(parent.send).toBeCalledTimes(1);
+  });
+
+  it("should change it thinking speed based on the provided delay", () => {
+    deps.thinkingDelay = 1; // <-- Changed delay
+    const parent = mockDeep<AnyInterpreter>();
+    const clock = new SimulatedClock();
+    const actor = interpret(createSmartPlayerMachine(deps), {
+      clock,
+      parent,
+    }).start();
+
+    const pile = buildPile();
+    actor.send(requestMove(pile));
+
     expect(parent.send).not.toBeCalled();
 
     clock.increment(1);

--- a/src/computer-players/smart-player-machine.ts
+++ b/src/computer-players/smart-player-machine.ts
@@ -27,10 +27,11 @@ function getInitialContext(): SmartPlayerContext {
 export interface SmartPlayerDependencies {
   /** The `secret` is provided by the game manager to verify moves from this actor. */
   secret: string;
+  thinkingDelay: number;
 }
 
 export function createSmartPlayerMachine(deps: SmartPlayerDependencies) {
-  /** @xstate-layout N4IgpgJg5mDOIC5QGUC2BDATgFwAoBt0BPMTAOgEkJ8wBiKdVMM1AewDc4zMwBHAVzjZEoAA6tYAS2yTWAOxEgAHogCMAVgAcZTetW7VAFgAMATgBsmzQCYA7ABoQRRNeumyh0182Xzt24ZGAL5BjmhYeIQk5AAqABaScgDWiVC0SrDY6NjM6ABmOZgAFNbGZQCUtOE4BMSkZPGJKXJQiuJSMvKKKgiexmTm5oa2pabGAMzmY4aOzgjWhtpe3prG5hqa48aaIWEYNVH1yPxQMJmpALIcdAxMLNewZOgAxs9gosJIIO3SsgpfPXG42sZFU1nGql8hks6msqlmams5jIEP8qmMsNKhi25l2IGqkTq5GOpyEl2u9EYzDYnEeEDAz3wiTAbQkvy6AMQtmMhjIxnB41sgyMxls41MCIQRnUOlUaLlG00w0MIVCIDkrHp8C+BNq0Uo1BZXx+nX+oB6AVBQsMcKMpiMNvMkoW4z5ZTKm3UlntYrxusOsQSyVSrI6f26iEm7mmJlsY1cQolThc2Ld7s93rl4z9+0J+pJZxkLSunFD7LNykQ5nFHkFniG+mVSbmqi8HmW3vMxlUkLWOYietIZdNEYQ6n6cqGts8DqRkvUvNRU3Gqxs6lM2PUqqCQA */
+  /** @xstate-layout N4IgpgJg5mDOIC5QGUC2BDATgFwAoBt0BPMTAOgEkJ8wBiKdVMM1AewDc4zMwBHAVzjZEoAA6tYAS2yTWAOxEgAHogCMAVgAcZTetW7VAFgAMATgBsmzQCYA7ABoQRRNeumyh0182Xzt24ZGAL5BjmhYeIQk5AAqABaScgDWiVC0SrDY6NjM6ABmOZgAFNgJyakAlLThOATEpGTxiSlyUIriUjLyiioIhubmZKoaqqZ65vqm1gDM5o7OCNPDZNaeFpoWxsPmxuYhYRi1UQ3I-FAwmakAshx0DEwst7Bk6ADGr2CiwkggHdKyCh+vWm02sQxmql8-V01lU8zU1kGS38qmM6lcxkM012+xANUi9XIp3OQmut3ojGYbE4zwgYFe+ESYHaEn+3SBiFsmLIxhm01sAyMxls01M8IQRnUOlUKJlGishgCIVCIDkrDp8B++Lq0Uo1GZPz+XUBoF6ASGAsMsKMpiMVrmThcWJ5xldxk003UlltItx2uOsTKLTahtZxp6iFm7lMmJMthjrgFYsdCFW0xdbo9Xo2MumfsOBN1xIuMlaN04LM6AIjCHMoo8-M85kCmkVnnFo3ca3Wm22OJV-sJlbZJuUiHUxgtzetnjtiPF6kMZGRIp8U2GelsyqCQA */
   return createMachine(
     {
       context: getInitialContext(),
@@ -50,7 +51,7 @@ export function createSmartPlayerMachine(deps: SmartPlayerDependencies) {
         },
         Thinking: {
           after: {
-            "2000": {
+            thinking: {
               target: "SuggestingMove",
             },
           },
@@ -71,6 +72,9 @@ export function createSmartPlayerMachine(deps: SmartPlayerDependencies) {
       },
     },
     {
+      delays: {
+        thinking: () => deps.thinkingDelay,
+      },
       actions: {
         saveGameState: assign((_, e) => ({
           freePositions: getFreePositions(e.pile),

--- a/src/computer-players/smart-player-machine.typegen.ts
+++ b/src/computer-players/smart-player-machine.typegen.ts
@@ -3,8 +3,8 @@
 export interface Typegen0 {
   "@@xstate/typegen": true;
   internalEvents: {
-    "xstate.after(2000)#SmartPlayer.Thinking": {
-      type: "xstate.after(2000)#SmartPlayer.Thinking";
+    "xstate.after(thinking)#SmartPlayer.Thinking": {
+      type: "xstate.after(thinking)#SmartPlayer.Thinking";
     };
     "xstate.init": { type: "xstate.init" };
   };
@@ -18,16 +18,18 @@ export interface Typegen0 {
   eventsCausingActions: {
     calculateMove:
       | "game.moves.decline"
-      | "xstate.after(2000)#SmartPlayer.Thinking";
+      | "xstate.after(thinking)#SmartPlayer.Thinking";
     respondWithMove:
       | "game.moves.decline"
-      | "xstate.after(2000)#SmartPlayer.Thinking";
+      | "xstate.after(thinking)#SmartPlayer.Thinking";
     saveGameState: "game.moves.request";
     updatePrevFree: "game.moves.accept";
   };
   eventsCausingServices: {};
   eventsCausingGuards: {};
-  eventsCausingDelays: {};
+  eventsCausingDelays: {
+    thinking: "game.moves.request";
+  };
   matchesStates: "Idle" | "SuggestingMove" | "Thinking";
   tags: never;
 }

--- a/tests/game-page.ts
+++ b/tests/game-page.ts
@@ -16,6 +16,13 @@ export class GamePage {
     }, takes);
   }
 
+  /** Changes the thinking speed of computer players. */
+  public downloadMoreCPU(thinkingDelay: number) {
+    return this.page.evaluate((delay: number) => {
+      window.thinkingDelay = delay;
+    }, thinkingDelay);
+  }
+
   readonly gameHeader = this.page.locator('h1 >> text="Nim - The Game"');
   readonly difficulty = this.page.locator(
     '*css=label >> text="Computer Difficulty:"'

--- a/tests/specs/interactions.spec.ts
+++ b/tests/specs/interactions.spec.ts
@@ -123,8 +123,9 @@ test.describe.parallel("Given the user plays a game", () => {
 
     await game.goto();
     await game.useSomeLuck(3);
-    await game.startBtn.click();
+    await game.downloadMoreCPU(2);
 
+    await game.startBtn.click();
     await expectMatchState();
 
     await game.match(5).click();

--- a/tests/specs/playing.spec.ts
+++ b/tests/specs/playing.spec.ts
@@ -5,14 +5,11 @@ test.describe.parallel("Given a computer at medium difficulty", () => {
   test("When the computer takes the last match, a win screen is shown", async ({
     page,
   }) => {
-    test.slow(
-      true,
-      "Plays against computers which require 2s each turn to think."
-    );
     const game = new GamePage(page);
 
     await game.goto();
     await game.useSomeLuck(3);
+    await game.downloadMoreCPU(1);
 
     await expect(game.difficulty).toHaveValue("medium");
     await game.startBtn.click();
@@ -44,14 +41,11 @@ test.describe.parallel("Given a computer at medium difficulty", () => {
   test("When the user takes the last match, a lose screen is shown", async ({
     page,
   }) => {
-    test.slow(
-      true,
-      "Plays against computers which require 2s each turn to think."
-    );
     const game = new GamePage(page);
 
     await game.goto();
     await game.useSomeLuck(3);
+    await game.downloadMoreCPU(1);
 
     await expect(game.difficulty).toHaveValue("medium");
     await game.startBtn.click();
@@ -84,13 +78,10 @@ test.describe.parallel("Given a computer at extreme difficulty", () => {
   test("When the user makes a move, the computer counters the move", async ({
     page,
   }) => {
-    test.slow(
-      true,
-      "Plays against computers which require 2s each turn to think."
-    );
     const game = new GamePage(page);
 
     await game.goto();
+    await game.downloadMoreCPU(1);
     await game.selectDifficulty("extreme");
 
     await game.startBtn.click();


### PR DESCRIPTION
The thinking speed of computer players can now be changed when they are initialized by overwriting `globalThis.thinkingDelay`. This can significantly speed up the e2e tests.